### PR TITLE
fix: SecondaryAttribute Input default value

### DIFF
--- a/src/components/CharacterSheet/SheetHeader.tsx
+++ b/src/components/CharacterSheet/SheetHeader.tsx
@@ -429,7 +429,7 @@ export const SheetHeader = ({ className, style }: SheetHeaderProps) => {
 																Number(finalValue)
 															);
 														}}
-														defaultValue={attrValue}
+														defaultValue={attrValue + (attrBonus || 0)}
 													/>
 												) : (
 													attrValue


### PR DESCRIPTION
Fixing the default value of SecondaryAttribute Input, to reflect the automatic value plus bonuses